### PR TITLE
Temporary solution for proxy support

### DIFF
--- a/main.js
+++ b/main.js
@@ -30,6 +30,13 @@ app.on('ready', function() {
 	});
 
 	TrayIcon.init(mainWindow);
+
+	if (Settings.ProxyRules) {
+		mainWindow.webContents.session.setProxy({
+			proxyRules: Settings.ProxyRules
+		}, () => {});
+	}
+
 	mainWindow.loadURL('file://' + __dirname + '/views/skype.html');
 });
 
@@ -42,6 +49,12 @@ electron.ipcMain.on('image:download', function(event, url) {
 			partition: 'persist:skype'
 		}
 	});
+
+	if (Settings.ProxyRules) {
+		tmpWindow.webContents.session.setProxy({
+			proxyRules: Settings.ProxyRules
+		}, () => {});
+	}
 
 	tmpWindow.webContents.session.once('will-download', function(event, downloadItem) {
 		let fileName = imageCache[url];

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,6 @@
 {
 	"StartMinimized": false,
 	"MicrosoftAccount": false,
-	"NativeImageViewer": false
+	"NativeImageViewer": false,
+	"ProxyRules": ""
 }

--- a/views/settings.html
+++ b/views/settings.html
@@ -97,7 +97,12 @@
 			fs.access(autostartFile, fs.F_OK, (err) => {
 				Settings.AutoStart = !err;
 				for (var key in Settings) {
-					$('[name="' + key + '"]').prop('checked', Settings[key]);
+					$elem = $('[name="' + key + '"]');
+
+					if (typeof Settings[key] === 'boolean')
+						$elem.prop('checked', Settings[key]);
+					else if (typeof Settings[key] === 'string')
+						$elem.val(Settings[key]);
 				}
 			});
 


### PR DESCRIPTION
This fixes #6 

There isn't currently a way to set this through the GUI; however, the format isn't too complicated. See here: http://electron.atom.io/docs/api/session/#sessetproxyconfig-callback

The proxy rules from the docs is what should be in the settings.json file.

How it works:
1. Add a setting call ProxyRules to ~/.config/Ghetto\ Skype/settings.json
2. Build Ghetto Skype from source using the README on this branch

I'll try to add this to the settings screen once we know it's working correctly.