### PR TITLE
Fix #14: Get BrowserWindow from electron first, then look for the module

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 const electron      = require('electron');
 const fs            = require('fs');
-const BrowserWindow = require('browser-window');
+const BrowserWindow = electron.BrowserWindow;
 const TrayIcon      = require('./tray');
 const spawn         = require('child_process').spawn;
 const tmp           = require('tmp');

--- a/tray.js
+++ b/tray.js
@@ -1,6 +1,6 @@
 const electron      = require('electron');
 const fs            = require('fs');
-const BrowserWindow = require('browser-window');
+const BrowserWindow = electron.BrowserWindow;
 
 let trayIcon       = null;
 let mainWindow     = null;


### PR DESCRIPTION
It seems that if you're using an external copy of electron-prebuilt, you need to bet BrowserWindow from electron.BrowserWindow instead of require('browser-window').