### PR TITLE
Use create-and-rename idiom for saving settings

### DIFF
--- a/app/GhettoSkype.js
+++ b/app/GhettoSkype.js
@@ -122,13 +122,17 @@ class GhettoSkype {
 		this.sendToRenderers('settings:updated', this.settings);
 
 		let data = JSON.stringify(this.settings, null, "\t");
-		fs.writeFile(settingsFile, data, (err) => {
+		fs.writeFile(settingsFile + '.tmp', data, (err) => {
 			if (err) throw err;
-
-			if (this.settingsWindow) {
-				this.settingsWindow.destroy();
-				this.settingsWindow = null;
-			}
+					 
+			fs.rename(settingsFile + '.tmp', settingsFile, (err) => {
+				if (err) throw err;
+					  
+				if (this.settingsWindow) {
+					this.settingsWindow.destroy();
+					this.settingsWindow = null;
+				}
+			});
 		});
 	}
 


### PR DESCRIPTION
On my machine, in vanilla ghetto-skype settings are often reverted to default on restart, as the settings file becomes corrupted. Using the create-and-rename idiom, by first creating the new settings file and then atomically moving it over the old one, guarantees that either the old or new version of the settings file will be preserved, and fixes the issue for me.

Fixes #31.