### PR TITLE
Added a tray button to reload/refresh the skype window

### DIFF
--- a/app/tray.js
+++ b/app/tray.js
@@ -65,6 +65,13 @@ let contextMenu = new electron.Menu.buildFromTemplate([
 		}
 	},
 	{
+		label: "Reload/Refresh",
+		click: () => {
+			mainWindow.show();
+			mainWindow.reload();
+		}
+	},
+	{
 		label: "Online Status",
 		submenu: [
 			{


### PR DESCRIPTION
I found that i was often having to manually close and reopen ghetto skype as I would have issue like being online, but not getting messages.

Other random issues, this would be a nice convenience feature I guess.