### PR TITLE
Change category of Ghetto Skype

### DIFF
--- a/assets/skype.desktop
+++ b/assets/skype.desktop
@@ -6,6 +6,6 @@ Comment=An unofficial client of Skype for Linux, using Electron.
 Icon=/opt/ghetto-skype/assets/tray/skype-big.png
 Exec=npm --prefix /opt/ghetto-skype start
 NoDisplay=false
-Categories=Network;
+Categories=Internet;
 StartupNotify=false
 Terminal=false


### PR DESCRIPTION
Change category from 'Network' to 'Internet'. The current category made Ghetto Skype to be in category Utilities on KDE distros.