### PR TITLE
New message count in tray. Now takes into account muted chats

### DIFF
--- a/src/skype.js
+++ b/src/skype.js
@@ -69,7 +69,11 @@
 
 		for (let i = unreadCounters.length - 1; i >= 0; i--) {
 			try {
-				sum += Number(unreadCounters[i].querySelector('p').textContent);
+                                let isMuted = unreadCounters[i].previousElementSibling.
+                                          classList.contains('notificationsDisabledIndicator');
+                                if (!isMuted) {
+                                    sum += Number(unreadCounters[i].querySelector('p').textContent);
+                                }
 			} catch(e) {
 				// if we're unlucky, unseenNotifications will be removed during the loop
 			}


### PR DESCRIPTION
See issue #142:
"When user selects "Turn notifications off" for a certain chat, new notification count for that chat should not be taken into account when new message count appears in tray! But now it is! In other words, the counter of new messages in tray summarizes all the new message counts for all the chats irrespectively whether they are muted or not!"

This pull request fixes this issue!